### PR TITLE
Typo def. 1.3 clause 3

### DIFF
--- a/chapter1/chapter1_forInclude.tex
+++ b/chapter1/chapter1_forInclude.tex
@@ -100,7 +100,7 @@ An event space associated with a sample space $ \Omega $ is a set $ \mathcal{A} 
 \begin{enumerate}
 \item $ \mathcal{A} $ is non-empty
 \item If $ A \in \mathcal{A} $ then $ A \subseteq \Omega $
-\item If $ A \in \mathcal{A} $ then $ \Omega\backslash \mathcal{A} \in \mathcal{A} $
+\item If $ A \in \mathcal{A} $ then $ \Omega\backslash A \in \mathcal{A} $
 \item If $ A,B \in \mathcal{A} $ then $ A \cup B \in \mathcal{A} $
 \end{enumerate}
 \end{Definition}


### PR DESCRIPTION
Changed clause 3 of definition 1.3 from omega\ curly A to omega\A, since it should say if A is in the event spce, then the complement of A is in the event space.

Christopher (10853138)
